### PR TITLE
fix: ui when device is connected, update battery when device connects

### DIFF
--- a/app/src/main/kotlin/app/DiGraph.kt
+++ b/app/src/main/kotlin/app/DiGraph.kt
@@ -15,6 +15,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.work.CoroutineWorker
+import androidx.work.Worker
 import earth.levi.batterybird.store.Database
 import earth.levi.batterybird.store.DatabaseStore
 import earth.levi.batterybird.store.DriverFactory
@@ -87,6 +89,5 @@ val Activity.diGraph: DiGraph
 val Service.diGraph: DiGraph
     get() = (application as MainApplication).diGraph
 
-// Designed to be called from a BroadcastReceiver or Worker.
-val Context.digraph: DiGraph?
-    get() = (this as? MainApplication)?.diGraph
+fun CoroutineWorker.getDiGraph(context: Context): DiGraph = (context as MainApplication).diGraph
+fun BroadcastReceiver.getDiGraph(context: Context): DiGraph = (context.applicationContext as MainApplication).diGraph

--- a/app/src/main/kotlin/app/android/Bluetooth.kt
+++ b/app/src/main/kotlin/app/android/Bluetooth.kt
@@ -27,6 +27,7 @@ interface Bluetooth: AndroidFeature {
     // Gets list of paired devices (or empty list if none), or Error if permissions not yet accepted
     fun getPairedDevices(context: Context): Result<List<BluetoothDeviceModel>>
     suspend fun getBatteryLevel(context: Context, device: BluetoothDeviceModel): Int?
+    fun isDeviceConnected(device: BluetoothDeviceModel): Boolean
     // if system bluetooth is on or not
     val isBluetoothOn: Boolean
 }
@@ -42,6 +43,8 @@ open class BluetoothImpl(private val log: Logger, private val bluetoothManager: 
         get() = bluetoothManager.adapter
 
     override fun canGetPairedDevices(context: Context): Boolean = areAllPermissionsGranted(context)
+
+    override fun isDeviceConnected(device: BluetoothDeviceModel): Boolean = device.isConnected
     
     @SuppressLint("MissingPermission") // we check if permission granted inside of the function.
     override fun getPairedDevices(context: Context): Result<List<BluetoothDeviceModel>> {

--- a/app/src/main/kotlin/app/extensions/KotlinxDateTimeExtensions.kt
+++ b/app/src/main/kotlin/app/extensions/KotlinxDateTimeExtensions.kt
@@ -3,7 +3,10 @@ package app.extensions
 import android.text.format.DateUtils
 import android.text.format.DateUtils.DAY_IN_MILLIS
 import android.text.format.DateUtils.MINUTE_IN_MILLIS
+import android.text.format.DateUtils.SECOND_IN_MILLIS
 import android.text.format.DateUtils.WEEK_IN_MILLIS
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimePeriod
 import kotlinx.datetime.Instant
@@ -25,7 +28,15 @@ fun Instant.toRelativeTimeSpanString(): String {
     val millisTimeAgo = this.toEpochMilliseconds()
     val millisNow = now().toEpochMilliseconds()
 
+    DateUtils.getRelativeTimeSpanString(millisTimeAgo, millisNow, SECOND_IN_MILLIS).toString().let { if (it.contains("ago")) return it }
     DateUtils.getRelativeTimeSpanString(millisTimeAgo, millisNow, MINUTE_IN_MILLIS).toString().let { if (it.contains("ago")) return it }
     DateUtils.getRelativeTimeSpanString(millisTimeAgo, millisNow, DAY_IN_MILLIS).toString().let { if (it.contains("ago")) return it }
     return DateUtils.getRelativeTimeSpanString(millisTimeAgo, millisNow, WEEK_IN_MILLIS).toString()
+}
+
+fun Instant.relativeTimeFlow(): Flow<String> = flow {
+    while (true) {
+        emit(this@relativeTimeFlow.toRelativeTimeSpanString())
+        delaySeconds(1)
+    }
 }

--- a/app/src/main/kotlin/app/repository/BluetoothDevicesRepository.kt
+++ b/app/src/main/kotlin/app/repository/BluetoothDevicesRepository.kt
@@ -14,6 +14,7 @@ import app.store.bluetoothDevicesStore
 import app.store.keyValueStorage
 import earth.levi.batterybird.BluetoothDeviceModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
 interface BluetoothDevicesRepository {
@@ -45,7 +46,7 @@ class BluetoothDevicesRepositoryImpl(
         val lastTimeConnected = if (newBatteryLevelIfDeviceConnected == null) null else now()
 
         // update the device in local store with the new battery level
-        devicesStore.devices = listOf(device.copy(batteryLevel = newBatteryLevelIfDeviceConnected?.toLong(), lastTimeConnected = lastTimeConnected))
+        devicesStore.devices = listOf(device.copy(batteryLevel = newBatteryLevelIfDeviceConnected?.toLong(), isConnected = bluetooth.isDeviceConnected(device), lastTimeConnected = lastTimeConnected))
 
         if (updateNotifications)  {
             // to make the app more reliable in making sure low battery notifications are shown, we use the cache as well as new battery level to cover the use case of: app killed, device battery low but device not connected, app started again.

--- a/app/src/main/kotlin/app/service/BluetoothDeviceMonitorBroadcastReceiver.kt
+++ b/app/src/main/kotlin/app/service/BluetoothDeviceMonitorBroadcastReceiver.kt
@@ -5,14 +5,16 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import app.DiGraph
+import app.MainApplication
 import app.android.workManager
-import app.digraph
+import app.getDiGraph
+import app.log.Logger
 import app.log.logger
 
 class BluetoothDeviceMonitorBroadcastReceiver:  BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
-        val diGraph = context.digraph ?: return
+        val diGraph = getDiGraph(context)
 
         val log = diGraph.logger
         val workManager = diGraph.workManager

--- a/app/src/main/kotlin/app/ui/view/DevicesList.kt
+++ b/app/src/main/kotlin/app/ui/view/DevicesList.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.extensions.findActivity
+import app.extensions.relativeTimeFlow
 import app.extensions.supportEmailIntent
 import app.extensions.systemBluetoothSettingsIntent
 import app.extensions.toRelativeTimeSpanString
@@ -233,13 +234,14 @@ fun CTAView(cta: AnyCTA, onClick: (AnyCTA) -> Unit, modifier: Modifier = Modifie
 fun DeviceLastConnectedText(device: BluetoothDeviceModel) {
     val isDeviceConnected = device.isConnected
     val hasDeviceEverBeenConnected = device.lastTimeConnected != null
+    val lastConnectedString = device.lastTimeConnected?.relativeTimeFlow()?.collectAsState(initial = "")
 
     val text = when {
-        isDeviceConnected -> "Connected"
-        hasDeviceEverBeenConnected -> "Last connected ${device.lastTimeConnected?.toRelativeTimeSpanString()}"
+        isDeviceConnected -> "Currently connected"
+        hasDeviceEverBeenConnected -> "Last connected ${lastConnectedString?.value ?: ""}"
         else -> "Connect device to get battery level"
     }
-
+    
     Text(text = text, color = Color.Gray, fontSize = 12.sp)
 }
 

--- a/app/src/main/kotlin/app/work/BluetoothDeviceBatteryCheckWorker.kt
+++ b/app/src/main/kotlin/app/work/BluetoothDeviceBatteryCheckWorker.kt
@@ -3,20 +3,30 @@ package app.work
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import app.DiGraph
-import app.digraph
+import app.extensions.secondsToMillis
+import app.getDiGraph
+import app.log.Logger
 import app.log.logger
+import app.repository.BluetoothDevicesRepository
 import app.repository.bluetoothDevicesRepository
+import kotlinx.coroutines.delay
 
 class BluetoothDeviceBatteryCheckWorker(context: Context, workerParameters: WorkerParameters): CoroutineWorker(context, workerParameters) {
 
-    private val log by lazy { context.digraph?.logger }
-    private val bluetoothDevicesRepository by lazy { context.digraph?.bluetoothDevicesRepository }
+    private lateinit var log: Logger
+    private lateinit var bluetoothDevicesRepository: BluetoothDevicesRepository
 
     override suspend fun doWork(): Result {
-        log?.debug("bluetooth device checker worker started", this)
+        getDiGraph(applicationContext).also { diGraph ->
+            log = diGraph.logger
+            bluetoothDevicesRepository = diGraph.bluetoothDevicesRepository
+        }
 
-        bluetoothDevicesRepository?.updateAllBatteryLevels(applicationContext, updateNotifications = true)
+        log.debug("bluetooth device checker worker started", this)
+
+        delay(2.secondsToMillis()) // hack. Sleep before checking battery levels. This is mostly for when a device just connected and we try to get the battery level for it immediately. Some devices only work by getting the battery level from the private Android OS call. Without this delay, the Android OS call returns null and then GATT is used which can cause issues (such as Sony WH-1000XM5 being disconnected when using GATT). Add this delay to make sure that the Android OS call will return the battery level.
+
+        bluetoothDevicesRepository.updateAllBatteryLevels(applicationContext, updateNotifications = true)
 
         return Result.success()
     }


### PR DESCRIPTION
Closes: https://github.com/levibostian/BatteryBird/issues/50
Closes: https://github.com/levibostian/BatteryBird/issues/52

## QA test cases 

#### Bluetooth permissions 
- [ ] Demo devices shown before permissions accepted. 
- [ ] After accept permissions, immediately see app populate with devices list and start to populate the battery levels. 
- [ ] Go into OS settings, deny permissions, go back into app. Should see cached data for devices and battery levels. 

#### Manually add devices 
- [ ] Help message shows when press help button on add devices screen. 
- [ ] Try adding a device with invalid hardware address. See error message. 
- [ ] Try adding same device hardware address multiple times. Should not see duplicate or replaced device. Should ignore request. 
- [ ] After adding a device, should see app try and get the battery level immediately after adding. 
- [ ] Add `ff:ff:ff:ff:ff:ff` as a device. I guess it's an invalid address according to the Android OS. So, Android `getRemoteDevice` will throw an exception. Verify that the app does not throw an exception. 

#### Devices list 
- [ ] App should update battery level immediately when app opens. 

### Broadcast receiver 
- [ ] When a device connects to OS, the battery level should be checked immediately. Test when app is killed. 

### Periodic battery level updates 
- [ ] When app is killed, battery level should be updated every 15 minutes. 

### Weird behaviors for some devices 
- [ ] Test app with Sony WH-1000XM5 headphones. This device when trying to use GATT causes the headphones to turn off. App should be able to get the bluetooth connection status and battery level when the headphones are connected and disconnected. 
- [ ] Test app with Coros Pace 2 watch. This device only works by manually adding the hardware address and using GATT to get battery level. 