### PR TITLE
feat: fresh new UI to take advantage of whitespace

### DIFF
--- a/app/src/main/kotlin/app/model/samples/SampleBluetoothDevices.kt
+++ b/app/src/main/kotlin/app/model/samples/SampleBluetoothDevices.kt
@@ -10,7 +10,7 @@ val Samples.bluetoothDevices: List<BluetoothDeviceModel>
         BluetoothDeviceModel("76:8X:36:JK:LA:N3", "Dining room speakers", 20, isConnected = false, lastTimeConnected = now().minus(days = 1, hours = 20, minutes = 5)),
         BluetoothDeviceModel("VN:4J:BC:HJ:73:B5", "Home office headphones", 100, isConnected = true, null),
         BluetoothDeviceModel("WX:1Z:2E:DG:08:83", "Pods", 40, isConnected = false, lastTimeConnected = now().minus(days = 12, hours = 3, minutes = 35)),
-        BluetoothDeviceModel("7V:OX:7C:IB:MN:17", "Music ear buds", 10, isConnected = false, lastTimeConnected = now().minus(days = 12, hours = 3, minutes = 35)),
+        BluetoothDeviceModel("7V:OX:7C:IB:MN:17", "Music ear buds", null, isConnected = false, lastTimeConnected = null),
     )
 
 val Samples.bluetoothDeviceModels: List<BluetoothDeviceModel>

--- a/app/src/main/kotlin/app/ui/theme/Color.kt
+++ b/app/src/main/kotlin/app/ui/theme/Color.kt
@@ -17,6 +17,7 @@ val StatusBarDark = Color.Black
 val BatteryLevelHigh = Color(0xFF4CB944)
 val BatteryLevelMedium = Color(0xFFF17300)
 val BatteryLevelLow = Color(0xFF92140C)
+val BatteryLevelUnknown = Color(0xFF6D6D6D) // when device has not been connected yet
 val BatteryLevelTrackLight = Color(0xFFCCCCCC)
 val BatteryLevelTrackDark = Color(0xFF494949)
 

--- a/app/src/main/res/drawable/not_connected_icon.xml
+++ b/app/src/main/res/drawable/not_connected_icon.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M4.125,10.222L15.12,0.11C15.438,-0.183 15.943,0.16 15.763,0.547L11.78,9.112L15.598,9.112C15.96,9.112 16.137,9.537 15.875,9.778L4.88,19.89C4.562,20.183 4.057,19.84 4.237,19.453L8.22,10.888L4.402,10.888C4.04,10.888 3.863,10.463 4.125,10.222L4.125,10.222Z"
+      android:strokeWidth="1"
+      android:fillColor="#6D6D6D"
+      android:fillType="evenOdd"
+      android:strokeColor="#00000000"/>
+  <path
+      android:pathData="M1.5,2.5L18.5,18.5"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#6D6D6D"
+      android:fillType="evenOdd"
+      android:strokeLineCap="square"/>
+</vector>


### PR DESCRIPTION
## QA test cases 

#### Bluetooth permissions 
- [ ] Demo devices shown before permissions accepted. 
- [ ] After accept permissions, immediately see app populate with devices list and start to populate the battery levels. 
- [ ] Go into OS settings, deny permissions, go back into app. Should see cached data for devices and battery levels. 

#### Manually add devices 
- [ ] Help message shows when press help button on add devices screen. 
- [ ] Try adding a device with invalid hardware address. See error message. 
- [ ] Try adding same device hardware address multiple times. Should not see duplicate or replaced device. Should ignore request. 
- [ ] After adding a device, should see app try and get the battery level immediately after adding. 
- [ ] Add `ff:ff:ff:ff:ff:ff` as a device. I guess it's an invalid address according to the Android OS. So, Android `getRemoteDevice` will throw an exception. Verify that the app does not throw an exception. 

#### Devices list 
- [ ] App should update battery level immediately when app opens. 

### Broadcast receiver 
- [ ] When a device connects to OS, the battery level should be checked immediately. Test when app is killed. 

### Periodic battery level updates 
- [ ] When app is killed, battery level should be updated every 15 minutes. 

### Weird behaviors for some devices 
- [ ] Test app with Sony WH-1000XM5 headphones. This device when trying to use GATT causes the headphones to turn off. App should be able to get the bluetooth connection status and battery level when the headphones are connected and disconnected. 
- [ ] Test app with Coros Pace 2 watch. This device only works by manually adding the hardware address and using GATT to get battery level. 