### PR TITLE
feat: edit name of device in app

### DIFF
--- a/app/src/main/kotlin/app/ui/view/EditDeviceNameDialog.kt
+++ b/app/src/main/kotlin/app/ui/view/EditDeviceNameDialog.kt
@@ -1,0 +1,87 @@
+package app.ui.view
+
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditDeviceNameDialog(
+    currentDeviceName: String,
+    done: (String?) -> Unit
+) {
+    var newNameValue by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = { done(null) },
+        properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = true)
+    ) {
+        Surface(
+            modifier = Modifier
+                .wrapContentWidth()
+                .wrapContentHeight(),
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = AlertDialogDefaults.TonalElevation
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = "Change the name of your device within the app.",
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = "Current name: $currentDeviceName",
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+
+                TextField(
+                    placeholder = { Text(text = "Workout headphones") },
+                    value = newNameValue,
+                    onValueChange = { newNameValue = it },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.End,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Button(onClick = { done(null) }) {
+                        Text(text = "Cancel")
+                    }
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    Button(onClick = {
+                        done(newNameValue)
+                    }) {
+                        Text(text = "Change name")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL
+)
+@Composable
+fun EditableTextDialogPreview() {
+    EditDeviceNameDialog("Current device name") {}
+}

--- a/app/src/main/kotlin/app/ui/view/HelpDialog.kt
+++ b/app/src/main/kotlin/app/ui/view/HelpDialog.kt
@@ -1,9 +1,11 @@
 package app.ui.view
 
+import android.content.res.Configuration
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
 fun HelpDialog(title: String = "", text: String, onDismiss: () -> Unit) {
@@ -17,4 +19,12 @@ fun HelpDialog(title: String = "", text: String, onDismiss: () -> Unit) {
         title = { if (text.isNotBlank()) Text(text = title) },
         text = { Text(text = text) }
     )
+}
+
+@Preview(showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL
+)
+@Composable
+fun HelpDialogPreview() {
+    HelpDialog(text = "This is a preview of the HelpDialog.") {}
 }

--- a/app/src/main/kotlin/app/viewmodel/BluetoothDevicesViewModel.kt
+++ b/app/src/main/kotlin/app/viewmodel/BluetoothDevicesViewModel.kt
@@ -112,4 +112,8 @@ class BluetoothDevicesViewModel(
         }
     }
 
+    fun updateDeviceName(deviceToEditName: BluetoothDeviceModel, newName: String) {
+        bluetoothDevicesStore.updateDevice(deviceToEditName.copy(name = newName))
+    }
+
 }

--- a/store/src/commonMain/sqldelight/earth/levi/batterybird/BluetoothDevice.sq
+++ b/store/src/commonMain/sqldelight/earth/levi/batterybird/BluetoothDevice.sq
@@ -20,6 +20,7 @@ INSERT INTO BluetoothDeviceModel (hardwareAddress, name, batteryLevel, isConnect
 VALUES (:hardwareAddress, :name, :batteryLevel, :isConnected, :lastTimeConnected)
 ON CONFLICT(hardwareAddress) DO UPDATE SET
     isConnected = :isConnected,
+    name = COALESCE(:name, name),
     batteryLevel = COALESCE(:batteryLevel, batteryLevel),
     lastTimeConnected = COALESCE(:lastTimeConnected, lastTimeConnected);
 


### PR DESCRIPTION
## QA test cases 

#### Bluetooth permissions 
- [ ] Demo devices shown before permissions accepted. 
- [ ] After accept permissions, immediately see app populate with devices list and start to populate the battery levels. 
- [ ] Go into OS settings, deny permissions, go back into app. Should see cached data for devices and battery levels. 

#### Manually add devices 
- [ ] Help message shows when press help button on add devices screen. 
- [ ] Try adding a device with invalid hardware address. See error message. 
- [ ] Try adding same device hardware address multiple times. Should not see duplicate or replaced device. Should ignore request. 
- [ ] After adding a device, should see app try and get the battery level immediately after adding. 
- [ ] Add `ff:ff:ff:ff:ff:ff` as a device. I guess it's an invalid address according to the Android OS. So, Android `getRemoteDevice` will throw an exception. Verify that the app does not throw an exception. 

#### Devices list 
- [ ] App should update battery level immediately when app opens. 

### Broadcast receiver 
- [ ] When a device connects to OS, the battery level should be checked immediately. Test when app is killed. 

### Periodic battery level updates 
- [ ] When app is killed, battery level should be updated every 15 minutes. 

### Weird behaviors for some devices 
- [ ] Test app with Sony WH-1000XM5 headphones. This device when trying to use GATT causes the headphones to turn off. App should be able to get the bluetooth connection status and battery level when the headphones are connected and disconnected. 
- [ ] Test app with Coros Pace 2 watch. This device only works by manually adding the hardware address and using GATT to get battery level. 